### PR TITLE
Errata:

### DIFF
--- a/src/recipes_tlsa.xml
+++ b/src/recipes_tlsa.xml
@@ -54,7 +54,7 @@ viM+cUnhD5UvhU4bn3ZP0cp+WNsimycf/gdfkAe47Em1oVNZP6abUgqMPStongIB
 
  <para>Next, use <command>openssl</command> to generate a SHA-256 fingerprint
  of this certificate, this is what you will list in DNS as a TLSA record. Also,
- you need to remove all the colons, hence the added <command>sed</command> at
+ you need to remove all the colons, hence the added <command>tr</command> at
  the end to filter out all ":" characters:</para>
 
  <screen># <userinput>openssl x509 -noout -fingerprint -sha256 &lt; server.crt | tr -d :</userinput>

--- a/src/signing_how-to-verify.xml
+++ b/src/signing_how-to-verify.xml
@@ -21,7 +21,7 @@ example.com.		300 IN DNSKEY 256 3 8 (
 				0qknWoPpkq0gIwTrYf3DJY+eIKPVHxrM+o2AoRIVhubG
 				jfv1bT5wTYrawZstS84ejCQ+ehA+8DxKyeWUEzW0ZMBe
 				OhyeG0cuQVK/p6Z1E096JLu0DjgbabLspequkw4M+HT7
-				) ; ZSK; alg = RSASHA256; key id = 57009
+				) ; ZSK; alg = RSASHA256; key id = 17694
 example.com.		300 IN DNSKEY 257 3 8 (
 				AwEAAdQ2ctHx8VmryndiOgpchXPdj3NwxMeUvAre6uYI
 				5KELlFJUghTHrz+/CzEc8CXG8wwQ4ZvAey0FGV2nJAFC
@@ -31,7 +31,7 @@ example.com.		300 IN DNSKEY 257 3 8 (
 				9bsWmhYWSHJKZ66+JnTiMS0nQM69YwBF43QfDKurs5R6
 				qPUDiBlaMCzSxmlaBU6fsI1Mu/yIU8w1ewy26a42rUTU
 				rPBC3Oa/zf9VQ8kpUrMZgJ7LEAA4xmR+qwWDh6U=
-				) ; KSK; alg = RSASHA256; key id = 28267</screen>
+				) ; KSK; alg = RSASHA256; key id = 06817</screen>
                 
   </para>
  </section>
@@ -73,7 +73,7 @@ example.com.		300 IN SOA ns1.example.com. dnsadmin.example.com. (
 				900        ; minimum (15 minutes)
 				)
 example.com.		300 IN RRSIG SOA 8 2 300 (
-				20141121122105 20141022112105 57009 example.com.
+				20141121122105 20141022112105 17694 example.com.
 				NqPGNLkUs40Lg/qq7Fv+bgyCwVB4s9PsHQOK6p9ZWWk3
 				36z2Qz2WjM+Q19SlVBAPux9jijvcRcjGb6KREuxER9uX
 				wdVeiGx9a4X+PaO3qTqdkiXuGS2XkK1kBm1CgwhVHTYV
@@ -162,8 +162,8 @@ OK</screen>
 ;example.com.			IN	DS
 
 ;; ANSWER SECTION:
-example.com.  61179	IN	DS	28267 8 1 66D47CE4B4F551BE5EDA43AC5F3109E8C98E2FAE
-example.com.  61179	IN	DS	28267 8 2 71D9335416B7132519190A95685E18CBF478DCF4CA98867062777938F8FEAB89</screen>
+example.com.  61179	IN	DS	06817 8 1 66D47CE4B4F551BE5EDA43AC5F3109E8C98E2FAE
+example.com.  61179	IN	DS	06817 8 2 71D9335416B7132519190A95685E18CBF478DCF4CA98867062777938F8FEAB89</screen>
 
   </para>
  </section>

--- a/src/signing_parent-zone.xml
+++ b/src/signing_parent-zone.xml
@@ -28,7 +28,7 @@
   <title>DS Record Format</title>
 
   <para>Below is an example of generating DS record formats from the KSK we
-  created earlier (<filename>Kexample.com.+008+28267.key</filename>) using two
+  created earlier (<filename>Kexample.com.+008+06817.key</filename>) using two
   different secure hashing algorithms (SHA-1 and SHA-256, respectively):</para>
 
   <screen># <userinput>cd /etc/bind/keys/example.com</userinput>
@@ -41,7 +41,7 @@ example.com. IN DS 6817 8 2 2A5F1DF55D5E64CBD7BCFE1EFA6E9586AF335FA56A2473296E97
   and digest used. In the first example, 8 represents the algorithm used, and 1
   represents the digest type (SHA-1); in the second example, 8 is the
   algorithm, and 2 is the digest type (SHA-256). The key tag or key ID is
-  28267.</para>
+  06817.</para>
 
   <para>Alternatively, you could generate it from the DNSKEY records like
   this:</para>


### PR DESCRIPTION
Sections 4.2.1, 4.2.2, 4.2.4, and 4.4.1 contained references to key tags
that don't match the keys generated in previous steps. Changing 28267 to
06817 (KSK) and 57009 to 17694 (ZSK) so they're consistent throughout the
guide.

Section 7.5 referred to `sed`, but `tr` is the command being used.