### PR TITLE
Fix typo in the custom DNSSEC Policy example (key -> keys)

### DIFF
--- a/doc/signing.rst
+++ b/doc/signing.rst
@@ -685,7 +685,7 @@ keys. The following is an example of such a clause:
 
    dnssec-policy standard {
        dnskey-ttl 600;
-       key {
+       keys {
            ksk lifetime 365d algorithm ecdsap256sha256;
            zsk lifetime 60d algorithm ecdsap256sha256;
        };


### PR DESCRIPTION
When copying the example bind will give an error in the log.
`config: error: /usr/local/etc/namedb/named.conf.dnssec-policy:3: unknown option 'key'`
Changing key to keys fixes this.